### PR TITLE
Add --output-ji test

### DIFF
--- a/ref/ref.txt
+++ b/ref/ref.txt
@@ -1,5 +1,5 @@
 cat,testname,res
-info,SysBenchVer,0.2.0
+info,SysBenchVer,0.2.1
 info,JuliaVer,1.4.1
 info,OS,Linux (x86_64-pc-linux-gnu)
 info,CPU,Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
@@ -7,21 +7,23 @@ info,WORD_SIZE,64
 info,LIBM,libopenlibm
 info,LLVM,"libLLVM-8.0.1 (ORCJIT, skylake)"
 info,GPU,GeForce GTX 1650 with Max-Q Design
-cpu,FloatMul,1.159e-6
-cpu,FusedMulAdd,1.7e-8
-cpu,FloatSin,4.0540000000000005e-6
-cpu,VecMulBroad,2.9813065326633165e-5
-cpu,CPUMatMul,0.018634
-cpu,MatMulBroad,0.0043675
-cpu,3DMulBroad,0.0010295999999999999
-cpu,peakflops,1.7255522888933444e11
-cpu,FFMPEGH264Write,107.505687
-gpu,GPUMatMul,0.005322875
-mem,DeepCopy,0.00018644988864142538
-diskio,DiskWrite1KB,0.0318615
-diskio,DiskWrite1MB,0.928177
-diskio,DiskRead1KB,0.006769
-diskio,DiskRead1MB,0.14344
-loading,JuliaLoad,91.214667
-compilation,compilecache,207.988182
-compilation,create_expr_cache,0.84871
+cpu,FloatMul,1.133e-6
+cpu,FusedMulAdd,1.1339999999999999e-6
+cpu,FloatSin,4.051e-6
+cpu,VecMulBroad,2.9825125628140703e-5
+cpu,CPUMatMul,0.018817
+cpu,MatMulBroad,0.0042099
+cpu,3DMulBroad,0.0010415
+cpu,peakflops,1.7780621689435773e11
+cpu,FFMPEGH264Write,107.928719
+gpu,GPUMatMul,0.0052633125
+mem,DeepCopy,0.000186327721661055
+diskio,DiskWrite1KB,0.0319535
+diskio,DiskWrite1MB,0.848287
+diskio,DiskRead1KB,0.00654375
+diskio,DiskRead1MB,0.144209
+loading,JuliaLoad,91.776181
+compilation,compilecache,208.8682705
+compilation,success_create_expr_cache,236.5010175
+compilation,create_expr_cache,1.129475
+compilation,output-ji-substart,32.713674999999995

--- a/src/SystemBenchmark.jl
+++ b/src/SystemBenchmark.jl
@@ -93,7 +93,7 @@ function comparetoref(test::DataFrame; refname="ref.txt")
 end
 
 function runbenchmark(;printsysinfo = true)
-    ntests = 18
+    ntests = 19
     if HAS_GPU[]
         ntests += 1
     else
@@ -147,10 +147,11 @@ function runbenchmark(;printsysinfo = true)
     deleteat!(LOAD_PATH,1); deleteat!(DEPOT_PATH,1)
 
     # calling create_expr_cache rapidly on windows seems to cause a LLVM malloc issue, so slowGC() is used as a teardown to slow the process
+    t = @benchmark success(io) setup=(io=Base.create_expr_cache($path, $cachefile, $concrete_deps, $pkg.uuid)) teardown=slowGC(); append!(df, DataFrame(cat="compilation", testname="success_create_expr_cache", res=(median(t).time / 1e6))); next!(prog)
     t = @benchmark Base.create_expr_cache($path, $cachefile, $concrete_deps, $pkg.uuid) teardown=slowGC(); append!(df, DataFrame(cat="compilation", testname="create_expr_cache", res=(median(t).time / 1e6))); next!(prog)
     
     t = @benchmark runjuliabasic(); startupoverhead = (median(t).time / 1e6)
-    t = @benchmark output_ji("module Foo bar(n)=sum(map(x->rand(),n)) end"); append!(df, DataFrame(cat="compilation", testname="output-ji-substart", res=(median(t).time / 1e6) - startupoverhead)); next!(prog)
+    t = @benchmark output_ji(); append!(df, DataFrame(cat="compilation", testname="output-ji-substart", res=(median(t).time / 1e6) - startupoverhead)); next!(prog)
     
     finish!(prog)
 
@@ -223,12 +224,13 @@ end
 function runjuliabasic()
     run(`$(Base.julia_cmd()) -O0 --startup-file=no --history-file=no --eval="1"`)
 end
-function output_ji(e)
+function output_ji()
+    examplemod = joinpath(@__DIR__, "ExampleModule.jl")
     tempout, io = mktemp()
     run(`$(Base.julia_cmd()) -O0 
         --output-ji $tempout --output-incremental=yes 
         --startup-file=no --history-file=no --warn-overwrite=yes 
-        --eval "$e"`)
+        --eval "include(\"$examplemod\")"`)
 end
 
 end #module

--- a/src/SystemBenchmark.jl
+++ b/src/SystemBenchmark.jl
@@ -157,12 +157,14 @@ function runbenchmark(;printsysinfo = true)
     @info "Printing of results may be truncated. To view the full results use `show(res, allrows=true, allcols=true)`"
     return df
 end
+
 ## CPU
 function writevideo(imgstack; delete::Bool=false, path = joinpath(@__DIR__, "testvideo.mp4"))
     VideoIO.encodevideo(path, imgstack, silent=true)
     delete && rm(path)
     return path
 end
+
 ## DiskIO
 function tempwrite(x; delete::Bool=false, path = joinpath(@__DIR__, "testwrite.dat"))
     open(path, "w") do io
@@ -177,25 +179,14 @@ function tempread(path)
     end
     return x
 end
+
 ## Julia Loading
 function runjulia(e)
     juliabin = joinpath(Sys.BINDIR, Base.julia_exename())
     run(`$(joinpath(Sys.BINDIR, Base.julia_exename())) --project=$(dirname(@__DIR__)) --startup-file=no -e "$e"`)
 end
 
-function runjuliabasic()
-    run(`$(Base.julia_cmd()) -O0 --startup-file=no --history-file=no --eval="1"`)
-end
-function output_ji(e)
-    tempout, io = mktemp()
-    run(`$(Base.julia_cmd()) -O0 
-        --output-ji $tempout --output-incremental=yes 
-        --startup-file=no --history-file=no --warn-overwrite=yes 
-        --eval "$e"`)
-end
-
 ## Compilation tests
-
 """
     compilecache_init(pkg)
 
@@ -225,10 +216,19 @@ function compilecache_init(pkg)
     end
     return path, cachefile, concrete_deps
 end
-
 function slowGC(t=0.1)
     GC.gc()
     sleep(t)
+end
+function runjuliabasic()
+    run(`$(Base.julia_cmd()) -O0 --startup-file=no --history-file=no --eval="1"`)
+end
+function output_ji(e)
+    tempout, io = mktemp()
+    run(`$(Base.julia_cmd()) -O0 
+        --output-ji $tempout --output-incremental=yes 
+        --startup-file=no --history-file=no --warn-overwrite=yes 
+        --eval "$e"`)
 end
 
 end #module


### PR DESCRIPTION
Adding more granular compilation tests to explore the inner process of 
https://github.com/JuliaLang/julia/blob/84d7e67aa82f3a3348a84a5a5659e03e2ebd6bcf/base/loading.jl#L1174

including a raw `--output-ji` test

The result is `output-ji-substart`, which has the overhead startup time for starting the same julia instance without the `--output-ji` args.
i.e. trying to get as close to the raw compilation time as possible