### PR TITLE
Add function to try `peakflops` on a range of different BLAS threads

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 VideoIO = "d6d074c3-1acf-5d4c-9a43-ef38773959a2"
 
 [compat]

--- a/src/SystemBenchmark.jl
+++ b/src/SystemBenchmark.jl
@@ -7,6 +7,7 @@ using InteractiveUtils
 using LinearAlgebra
 using Logging
 using ProgressMeter
+using UnicodePlots
 using VideoIO
 
 include("utils.jl")
@@ -118,10 +119,15 @@ function get_peakflops(range = 1:min(32, Sys.CPU_THREADS))
     orig_blas_threads = BLAS.get_num_threads()
     res = map(range) do n
         BLAS.set_num_threads(n)
-        (n, maximum(peakflops() for _ in 1:10))
+        GC.enable(true)
+        GC.gc(true)
+        GC.enable(false)
+        maximum(peakflops() for _ in 1:100)
     end
+    GC.gc()
     # restore BLAS threads
     BLAS.set_num_threads(orig_blas_threads)
+    display(barplot(1:length(res), res, width = 100, ylabel = "BLAS threads", title = "peakflops vs. BLAS threads"))
     return res
 end
 

--- a/src/SystemBenchmark.jl
+++ b/src/SystemBenchmark.jl
@@ -110,7 +110,20 @@ function diskio(;num_zeros = 3:5, digits=1:9)
 	end
 end
 
-
+# Function to get the peakflops on a range of different BLAS threads.  By
+# default we go from 1 to the number of CPU threads, capped at 32, as that's the
+# maximum value of threads of the default OpenBLAS implementation, but users can
+# tweak this range to try a wider range, if they can/want.
+function get_peakflops(range = 1:min(32, Sys.CPU_THREADS))
+    orig_blas_threads = BLAS.get_num_threads()
+    res = map(range) do n
+        BLAS.set_num_threads(n)
+        (n, maximum(peakflops() for _ in 1:10))
+    end
+    # restore BLAS threads
+    BLAS.set_num_threads(orig_blas_threads)
+    return res
+end
 
 function runbenchmark(;printsysinfo = true, slowgcsleep = 1.0)
     ntests = 18


### PR DESCRIPTION
Another follow up from https://github.com/IanButterworth/SystemBenchmark.jl/issues/8#issuecomment-897649742.  With this function we can probe `peakflops` for different values of BLAS threads.  Only problem is that I don't know how to present this result :sweat_smile:  So I'm opening a draft for the time being